### PR TITLE
Handle duplicate user emails. Closes #5

### DIFF
--- a/src/api_test.py
+++ b/src/api_test.py
@@ -10,6 +10,27 @@ def app():
     app = create_app(config_file='test_config.py')
     return app
 
+def test_email_already_registered(client, mocker):
+    db.create_all()
+
+    mocker.patch('email_client.send_verification_email')
+
+    res = client.post('/api/users/', headers={'Content-Type': 'application/json'},
+                      data=json.dumps(dict(email='e@mail.edu', password='hunter2')))
+    assert res.status_code == 201
+
+    [user1] = User.query.all()
+
+    res = client.post('/api/users/', headers={'Content-Type': 'application/json'},
+                      data=json.dumps(dict(email='e@mail.edu', password='hunter2')))
+    assert res.status_code == 201
+
+    [user2] = User.query.all()
+
+    assert user1 == user2
+
+    db.drop_all()
+
 def test_create_user_flow(client, mocker):
     db.create_all()
 

--- a/src/routes.py
+++ b/src/routes.py
@@ -39,7 +39,6 @@ class CreateUser(Resource):
     @namespace.expect(create_user_model)
     @namespace.marshal_with(user_model, code=201)
     def post(self):
-        # TODO do something graceful on unique email integrity constraint violation.
         user = User(
             hashed_pw=auth_util.hash_pw(api.payload['password']),
             email=api.payload['email'])


### PR DESCRIPTION
Respond as if account creation was successful. This way we don't leak
information about whether an email is registered with Quokka or not.