### PR TITLE
Use remote postgres for tests

### DIFF
--- a/src/test_config.py
+++ b/src/test_config.py
@@ -1,3 +1,11 @@
+import os
+import subprocess
+
 DEBUG = True
-SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
+if 'TEST_DB_URL' in os.environ:
+    SQLALCHEMY_DATABASE_URI = os.environ.get('TEST_DB_URL')
+else:
+    SQLALCHEMY_DATABASE_URI = subprocess.check_output(
+            "heroku config --app quokka-api-test-db | grep DATABASE_URL | awk '{print $2}'",
+            shell=True).decode('utf-8')
 SQLALCHEMY_TRACK_MODIFICATIONS = False


### PR DESCRIPTION
It looks like there is a problem with postgres actually. It's possible that we can't use user as a table name. I can investigate, but if you have time can you take a look?

Check this branch out and run make test. I see:

=================================================================================== FAILURES ===================================================================================
________________________________________________________________________ test_email_already_registered _________________________________________________________________________

client = <FlaskClient <Flask 'app'>>, mocker = <pytest_mock.MockFixture object at 0x7f4347bb6fd0>

    def test_email_already_registered(client, mocker):
        db.create_all()

        mocker.patch('email_client.send_verification_email')

        res = client.post('/api/users/', headers={'Content-Type': 'application/json'},
                          data=json.dumps(dict(email='e@mail.edu', password='hunter2')))
        assert res.status_code == 201

>       [user1] = User.query.all()
E       ValueError: not enough values to unpack (expected 1, got 0)

src/api_test.py:22: ValueError
---------------------------------------------------------------------------- Captured stderr setup -----------------------------------------------------------------------------
 ▸    heroku-cli: update available from 6.12.17 to 6.13.18-a444c52
____________________________________________________________________________ test_create_user_flow _____________________________________________________________________________

client = <FlaskClient <Flask 'app'>>, mocker = <pytest_mock.MockFixture object at 0x7f4343e05a20>

    def test_create_user_flow(client, mocker):
        db.create_all()

        mocker.patch('email_client.send_verification_email')

        res = client.post('/api/users/', headers={'Content-Type': 'application/json'},
                          data=json.dumps(dict(email='e@mail.edu', password='hunter2')))

>       [user] = User.query.all()
E       ValueError: not enough values to unpack (expected 1, got 0)

src/api_test.py:42: ValueError
---------------------------------------------------------------------------- Captured stderr setup -----------------------------------------------------------------------------
 ▸    heroku-cli: update available from 6.12.17 to 6.13.18-a444c52
===================================================================== 2 failed, 2 passed in 10.84 seconds ======================================================================
Makefile:3: recipe for target 'test' failed
make: *** [test] Error 1
